### PR TITLE
Reusable parsers

### DIFF
--- a/spec/phreak/instance_spec.cr
+++ b/spec/phreak/instance_spec.cr
@@ -1,0 +1,23 @@
+require "../../src/*"
+require "spec"
+
+describe Phreak do
+  describe "#create_parser" do
+    it "Allows a parser to be reused" do
+      # Keep track of the number of times the endpoint
+      # executes.
+      count = 0
+
+      parser = Phreak.create_parser do |root|
+        root.bind(word: "endpoint") do |sub|
+          count += 1
+        end
+      end
+
+      (1..5).each do |x|
+        parser.parse(["endpoint"])
+        count.should eq x
+      end
+    end
+  end
+end

--- a/spec/phreak/parser_spec.cr
+++ b/spec/phreak/parser_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "../../src/*"
 
-describe Phreak::Parser do
+describe Phreak::RootParser do
   describe "#next_token" do
     it "returns the next token in the argument list" do
       Phreak.parse("arg1 arg2".split(" ")) do |root|

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -1,49 +1,23 @@
 require "./subparser.cr"
 
 module Phreak
-  # The internal master parsing class. This is where everything is initially kicked off.
-  class Parser < Subparser
-    @default_action_handler : Proc(Void)
+  # This class serves as a reusable form of `Phreak.parse`. This allows
+  # for a variety of uses, such as more readable code, complex interpreters,
+  # and even text adventure games.
+  class Parser
+    @block : Proc(RootParser, Nil)
 
-    def initialize(@args : Array(String))
-      @missing_arguments_handler = ->(apex : String) do
-        raise InsufficientArgumentsException.new "Insufficient arguments provided after keyword '#{apex}', and no handlers specified."
-      end
-
-      @unrecognized_arguments_handler = ->(name : String) do
-        raise UnrecognizedTokenException.new "Unrecognized token '#{name}' encountered, with no unrecognized argument handlers specified."
-      end
-
-      @default_action_handler = ->do
-        # Do nothing
-      end
+    def initialize(@block)
     end
 
-    # Starts the parsing chain. If there are no arguments to parse, the default action handler will be called.
-    protected def begin_parsing : Nil
-      if @args.size == 0
-        @default_action_handler.call
-      else
-        process_token(next_token, self)
+    def parse!
+      parse(ARGV)
+    end
+
+    def parse(args : Array(String))
+      Phreak.parse(args) do |root|
+        @block.call root
       end
-    end
-
-    # Returns the next token, if available. Will raise an exception if `@args.size == 0`
-    def next_token : String | Nil
-      # If there isn't a token, throw an exception
-      raise InsufficientArgumentsException.new unless token_available?
-      # This just returns the first thing in the args array
-      @args.delete_at(0)
-    end
-
-    # Returns true if there is at least one token remaining to be parsed.
-    def token_available? : Bool
-      @args.size > 0
-    end
-
-    # Yields to a callback if `Phreak::parse` is called with no arguments.
-    def default(&block : Proc(Void))
-      @default_action_handler = block
     end
   end
 end

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -10,10 +10,7 @@ module Phreak
     def initialize(@block)
     end
 
-    def parse!
-      parse(ARGV)
-    end
-
+    # Invokes the parser on an array of arguments.
     def parse(args : Array(String))
       Phreak.parse(args) do |root|
         @block.call root

--- a/src/phreak.cr
+++ b/src/phreak.cr
@@ -1,29 +1,38 @@
 require "./parser.cr"
 require "./subparser.cr"
+require "./root_parser.cr"
 
-# Phreak is a library for creating CLIs in the style of Crystal's built in OptionParser,
+# Phreak is a library for creating CLIs in the style of Crystal's built in OptionRootParser,
 # but with much more flexibility.
 module Phreak
   extend self
   VERSION = "0.1.0"
 
   # Equivalent to invoking `Phreak::parse` with args = ARGV.
-  def self.parse!(&block : Parser -> Nil) : Nil
-    parse ARGV do |sp|
-      block.call sp
+  def self.parse!(&block : RootParser -> Nil) : Nil
+    parse ARGV do |root|
+      block.call root
     end
   end
 
   # Initializes a parser, and yields to a setup block with the created
   # subparser.
-  def self.parse(args : Array(String), &block : Parser -> Nil) : Nil
-    # First, we create a master parser. See the documenation of `Phreak::Parser`
+  def self.parse(args : Array(String), &block : RootParser -> Nil) : Nil
+    # First, we create a master parser. See the documenation of `Phreak::RootParser`
     # for more details on what it is, and why it's an extended subparser.
-    parser = Parser.new args
+    parser = RootParser.new args
     # Now, we call the setup block - this is where the CLI can create bindings
     # to the parser instance.
     yield parser
     # Finally, we can actually parse the arguments.
     parser.begin_parsing
+  end
+
+  # Creates a reusable instance of `Parser`. This is opposed to other
+  # class methods on Phreak, which are single-use. As a note, this
+  # can also be done using Parser.new, but using this method is
+  # preferred style for consistency.
+  def self.create_parser(&block : RootParser -> Nil) : Parser
+    Parser.new(block)
   end
 end

--- a/src/root_parser.cr
+++ b/src/root_parser.cr
@@ -14,7 +14,7 @@ module Phreak
         raise UnrecognizedTokenException.new "Unrecognized token '#{name}' encountered, with no unrecognized argument handlers specified."
       end
 
-      @default_action_handler = -> do
+      @default_action_handler = ->do
         # Do nothing
       end
     end

--- a/src/root_parser.cr
+++ b/src/root_parser.cr
@@ -1,0 +1,49 @@
+require "./subparser.cr"
+
+module Phreak
+  # The internal master parsing class. This is where everything is initially kicked off.
+  class RootParser < Subparser
+    @default_action_handler : Proc(Void)
+
+    def initialize(@args : Array(String))
+      @missing_arguments_handler = ->(apex : String) do
+        raise InsufficientArgumentsException.new "Insufficient arguments provided after keyword '#{apex}', and no handlers specified."
+      end
+
+      @unrecognized_arguments_handler = ->(name : String) do
+        raise UnrecognizedTokenException.new "Unrecognized token '#{name}' encountered, with no unrecognized argument handlers specified."
+      end
+
+      @default_action_handler = -> do
+        # Do nothing
+      end
+    end
+
+    # Starts the parsing chain. If there are no arguments to parse, the default action handler will be called.
+    protected def begin_parsing : Nil
+      if @args.size == 0
+        @default_action_handler.call
+      else
+        process_token(next_token, self)
+      end
+    end
+
+    # Returns the next token, if available. Will raise an exception if `@args.size == 0`
+    def next_token : String | Nil
+      # If there isn't a token, throw an exception
+      raise InsufficientArgumentsException.new unless token_available?
+      # This just returns the first thing in the args array
+      @args.delete_at(0)
+    end
+
+    # Returns true if there is at least one token remaining to be parsed.
+    def token_available? : Bool
+      @args.size > 0
+    end
+
+    # Yields to a callback if `Phreak::parse` is called with no arguments.
+    def default(&block : Proc(Void))
+      @default_action_handler = block
+    end
+  end
+end


### PR DESCRIPTION
One feature I've wanted to incorporate for a while is the ability to reuse a parser. This extends phreak substantially with only a little bit of code - in fact, it's really the only feature needed to go from a CLI to a text adventure game.

This branch implements that, and I'm excited about the potential it brings.

Note:
As this project is still small, I figured I could get away with a very minor refactor. The class that was formerly known as `Parser` has been renamed to `RootParser`, which is a more accurate description of its behavior. Reusable parsers are now instances of the new version of the `Parser` datatype. This should hopefully not be a problem - it would only affect users who were explicitly declaring the types of the subparsers that Phreak was yielding.